### PR TITLE
Update spring boot gradle plugin example for specifying image name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -465,7 +465,7 @@ and in Gradle using
 
 ```groovy
 bootBuildImage {
-	builder = "myorg/demo"
+	imageName = "myorg/demo"
 }
 ```
 


### PR DESCRIPTION
As per https://github.com/spring-projects/spring-boot/blob/5d7df790f1bde3698bfacc920711e49e58bc6048/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImage.java#L111