### PR TITLE
Fix Gradle snippet in Spring Boot Plugins

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -465,7 +465,7 @@ and in Gradle using
 
 ```groovy
 bootBuildImage {
-	builder = "myorg/demo"
+	imageName = "myorg/demo"
 }
 ```
 


### PR DESCRIPTION
The snippet accidentally uses `builder` instead of `imageName`.

You can modify the image name ... in Gradle using `bootBuildImage.imageName`. (Was `bootBuildImage.builder`)
```
bootBuildImage {
	imageName = "myorg/demo"
}
```