### PR TITLE
Merge duplicate Boot plugin sections and add layertools section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ NOTE: There is also a Getting Started Guide on https://spring.io/guides/gs/sprin
 
 == A Basic Dockerfile
 
-A Spring Boot application is easy to convert into an executable JAR file. All the https://spring.io/guides[Getting Started Guides] do this, and every applicaiton that you download from https://start.spring.io[Spring Initializr] has a build step to create an executable JAR. With Maven, you run `./mvnw install`, With Gradle, you run `./gradlew build`. A basic Dockerfile to run that JAR would then look like this, at the top level of your project:
+A Spring Boot application is easy to convert into an executable JAR file. All the https://spring.io/guides[Getting Started Guides] do this, and every application that you download from https://start.spring.io[Spring Initializr] has a build step to create an executable JAR. With Maven, you run `./mvnw install`, With Gradle, you run `./gradlew build`. A basic Dockerfile to run that JAR would then look like this, at the top level of your project:
 
 `Dockerfile`
 ====
@@ -70,7 +70,7 @@ docker build -t myorg/myapp .
 ----
 ====
 
-The we can run it by running the following command:
+Then we can run it by running the following command:
 
 ====
 [source,bash]
@@ -311,7 +311,7 @@ The docker configuration is very simple so far, and the generated image is not v
 
 === Smaller Images
 
-Notice that the base image in the earlier example is `openjdk:8-jdk-alpine`. The `alpine` images are smaller than the standard `openjdk` library images from https://hub.docker.com/_/openjdk/[Dockerhub]. There is no official alpine image for Java 11 yet. You can also save about 20MB in the base image by using the `jre` label instead of `jdk`. Not all applications work with a JRE (as opposed to a JDK), but most do. Some organizations enforce a rule that every application has to work with a JRE because of the risk of misuse of some of the JDK features (such as compilation).
+Notice that the base image in the earlier example is `openjdk:8-jdk-alpine`. The `alpine` images are smaller than the standard `openjdk` library images from https://hub.docker.com/_/openjdk/[Dockerhub]. You can also save about 20MB in the base image by using the `jre` label instead of `jdk`. Not all applications work with a JRE (as opposed to a JDK), but most do. Some organizations enforce a rule that every application has to work with a JRE because of the risk of misuse of some of the JDK features (such as compilation).
 
 Another trick that could get you a smaller image is to use https://openjdk.java.net/projects/jigsaw/quick-start#linker[JLink], which is bundled with OpenJDK 11. JLink lets you build a custom JRE distribution from a subset of modules in the full JDK, so you do not need a JRE or JDK in the base image. In principle, this would get you a smaller total image size than using the `openjdk` official docker images. In practice, you cannot (yet) use the `alpine` base image with JDK 11, so your choice of base image is limited and probably results in a larger final image size. Also, a custom JRE in your own base image cannot be shared among other applications, since they would need different customizations. So you might have smaller images for all your applications, but they still take longer to start because they do not benefit from caching the JRE layer.
 
@@ -349,11 +349,49 @@ ENTRYPOINT ["java","-cp","app:app/lib/*","hello.Application"]
 
 There are now three layers, with all the application resources in the later two layers. If the application dependencies do not change, the first layer (from `BOOT-INF/lib`) need not change, so the build is faster, and the startup of the container at runtime if also faster, as long as the base layers are already cached.
 
-NOTE: We used a hard-coded main application class: `hello.Application`. This is probably different for your application. You could parameterize it with another `ARG` if you wanted. You could also copy the Spring Boot fat `JarLauncher` into the image and use it to run the applicaiton. It would work and you would not need to specify the main class, but it would be a bit slower on startup.
+NOTE: We used a hard-coded main application class: `hello.Application`. This is probably different for your application. You could parameterize it with another `ARG` if you wanted. You could also copy the Spring Boot fat `JarLauncher` into the image and use it to run the application. It would work and you would not need to specify the main class, but it would be a bit slower on startup.
+
+=== Spring Boot Layer Index
+
+Starting with Spring Boot 2.3.0, a JAR file built with the Spring Boot Maven or Gradle plugin includes https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#features.container-images.layering[layer information] in the JAR file.
+This layer information separates parts of the application based on how likely they are to change between application builds.
+This can be used to make Docker image layers even more efficient.
+
+The layer information can be used to extract the JAR contents into a directory for each layer:
+
+====
+[source,bash]
+----
+mkdir target/extracted
+java -Djarmode=layertools -jar target/*.jar extract --destination target/extracted
+docker build -t myorg/myapp .
+----
+====
+
+Then we can use the following `Dockerfile`:
+
+`Dockerfile`
+====
+[source]
+----
+FROM openjdk:8-jdk-alpine
+VOLUME /tmp
+ARG EXTRACTED=/workspace/app/target/extracted
+COPY ${EXTRACTED}/dependencies/ ./
+COPY ${EXTRACTED}/spring-boot-loader/ ./
+COPY ${EXTRACTED}/snapshot-dependencies/ ./
+COPY ${EXTRACTED}/application/ ./
+ENTRYPOINT ["java","org.springframework.boot.loader.JarLauncher"]
+----
+====
+
+NOTE: The Spring Boot fat `JarLauncher` is extracted from the JAR into the image, so it can be used to start the application without hard-coding the main application class.
+
+See the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#features.container-images.building.dockerfiles[Spring Boot documentation] for more information on using the layering feature.
 
 == Tweaks
 
-If you want to start your applicaiton as quickly as possible (most people do), you might consider some tweaks:
+If you want to start your application as quickly as possible (most people do), you might consider some tweaks:
 
 * Use the `spring-context-indexer` (https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans-scanning-index[link to docs]). It is not going to add much for small applications, but every little helps.
 * Do not use https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#production-ready[actuators] if you can afford not to.
@@ -537,71 +575,57 @@ As mentioned earlier, this also saves some space in the image, which would be oc
 
 If you do not want to call `docker` directly in your build, there is a rich set of plugins for Maven and Gradle that can do that work for you. Here are just a few.
 
-=== Spring Boot Plugins
+=== Spring Boot Maven and Gradle Plugins
 
-With Spring Boot 2.3, you can build an image from Maven or Gradle directly with Spring Boot. As long as you already build a Spring Boot JAR file, you need only call the plugin directly. The following listing shows how to do so with https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/html/#build-image[Maven]:
+You can use the Spring Boot build plugins for https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#build-image[Maven] and https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#build-image[Gradle] to create container images.
+The plugins create an OCI image (the same format as one created by `docker build`) by using https://buildpacks.io/[Cloud Native Buildpacks].
+You do not need a `Dockerfile`, but you do need a Docker daemon, either locally (which is what you use when you build with docker) or remotely through the `DOCKER_HOST` environment variable.
+The default builder is optimized for Spring Boot applications, and the image is layered efficiently as in the examples above.
 
-====
-[source,bash]
-----
-./mvnw spring-boot:build-image
-----
-====
-
-The following list shows how to call the plugin directly with https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/html/#build-image[Gradle]:
+The following example works with Maven without changing the `pom.xml` file:
 
 ====
 [source,bash]
 ----
-$ ./gradlew bootBuildImage
+./mvnw spring-boot:build-image -Dspring-boot.build-image.imageName=myorg/myapp
 ----
 ====
 
-It uses the local docker daemon (which, therefore, must be installed) but does not require a `Dockerfile`. The result is an image called (by default) `docker.io/<group>/<artifact>:latest`. You can modify the image name in Maven using as follows:
-
-====
-[source,xml]
-----
-<project>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<image>
-						<name>myorg.demo</name>
-					</image>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-</project>
-----
-====
-
-You can modify the image name in Gradle using as follows:
-
-====
-[source,groovy]
-----
-bootBuildImage {
-	imageName = "myorg/demo"
-}
-----
-====
-
-The image is built by using https://buildpacks.io/[Cloud Native Buildpacks], where the default builder is optimized for a Spring Boot application (you can customize it, but the defaults are useful). The image is layered efficiently, as in the examples above. It also uses the CF memory calculator to size the JVM at runtime based on the container resources available, so, when you run the image, you see the memory calculator reporting its results:
+The following example works with Gradle, without changing the `build.gradle` file:
 
 ====
 [source,bash]
 ----
-docker run -p 8080:8080 myorg/demo
-Container memory limit unset. Configuring JVM for 1G container.
-Calculated JVM Memory Configuration: -XX:MaxDirectMemorySize=10M -XX:MaxMetaspaceSize=86557K -XX:ReservedCodeCacheSize=240M -Xss1M -Xmx450018K (Head Room: 0%, Loaded Class Count: 12868, Thread Count: 250, Total Memory: 1073741824)
-...
+./gradlew bootBuildImage --imageName=myorg/myapp
 ----
 ====
+
+The first build might take a long time because it has to download some container images and the JDK, but subsequent builds should be fast.
+
+Then you can run the image, as the following listing shows (with output):
+
+====
+[source,bash]
+----
+docker run -p 8080:8080 -t myorg/myapp
+Setting Active Processor Count to 6
+Calculating JVM memory based on 14673596K available memory
+Calculated JVM Memory Configuration: -XX:MaxDirectMemorySize=10M -Xmx14278122K -XX:MaxMetaspaceSize=88273K -XX:ReservedCodeCacheSize=240M -Xss1M (Total Memory: 14673596K, Thread Count: 50, Loaded Class Count: 13171, Headroom: 0%)
+Adding 129 container CA certificates to JVM truststore
+Spring Cloud Bindings Enabled
+Picked up JAVA_TOOL_OPTIONS: -Djava.security.properties=/layers/paketo-buildpacks_bellsoft-liberica/java-security-properties/java-security.properties -agentpath:/layers/paketo-buildpacks_bellsoft-liberica/jvmkill/jvmkill-1.16.0-RELEASE.so=printHeapHistogram=1 -XX:ActiveProcessorCount=6 -XX:MaxDirectMemorySize=10M -Xmx14278122K -XX:MaxMetaspaceSize=88273K -XX:ReservedCodeCacheSize=240M -Xss1M -Dorg.springframework.cloud.bindings.boot.enable=true
+....
+2015-03-31 13:25:48.035  INFO 1 --- [           main] s.b.c.e.t.TomcatEmbeddedServletContainer : Tomcat started on port(s): 8080 (http)
+2015-03-31 13:25:48.037  INFO 1 --- [           main] hello.Application
+----
+====
+
+You can see the application start up as normal.
+You might also notice that the JVM memory requirements were computed and set as command line options inside the container.
+This is the same memory calculation that has been in use in Cloud Foundry build packs for many years.
+It represents significant research into the best choices for a range of JVM applications, including but not limited to Spring Boot applications, and the results are usually much better than the default setting from the JVM.
+You can customize the command line options and override the memory calculator by setting environment variables as shown in the https://paketo.io/docs/howto/java/[Paketo buildpacks documentation].
+
 
 === Spotify Maven Plugin
 
@@ -707,46 +731,6 @@ docker {
 ====
 
 In this example, we have chosen to unpack the Spring Boot fat JAR in a specific location in the `build` directory, which is the root for the docker build. Then the multi-layer (not multi-stage) `Dockerfile` shown earlier works.
-
-=== Spring Boot Maven and Gradle Plugins
-
-You can use the Spring Boot build plugins for https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/maven-plugin/reference/html/#build-image[Maven] and https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/gradle-plugin/reference/html/#build-image[Gradle] to create container images. The plugins create an OCI image (the same format as one created by `docker build`) by using https://buildpacks.io/[Cloud Native Buildpacks].  You do not need a `Dockerfile`, but you do need a docker daemon, either locally (which is what you use when you build with docker) or remotely through the `DOCKER_HOST` environment variable.
-
-The following example works with Maven without changing the `pom.xml` file:
-
-====
-[source,bash]
-----
-./mvnw spring-boot:build-image -Dspring-boot.build-image.imageName=myorg/myapp
-----
-====
-
-The following example works with Gradle, without changing the `build.gradle` file:
-
-====
-[source,bash]
-----
-./gradlew bootBuildImage --imageName=myorg/myapp
-----
-====
-
-The first build might take a long time because it has to download some container images and the JDK, but subsequent builds should be fast.
-
-Then you can run the image, as the following listing shows (with output):
-
-====
-[source,bash]
-----
-docker run -p 8080:8080 -t myorg/myapp
-Container memory limit unset. Configuring JVM for 1G container.
-Calculated JVM Memory Configuration: -XX:MaxDirectMemorySize=10M -XX:MaxMetaspaceSize=86381K -XX:ReservedCodeCacheSize=240M -Xss1M -Xmx450194K (Head Room: 0%, Loaded Class Count: 12837, Thread Count: 250, Total Memory: 1073741824)
-....
-2015-03-31 13:25:48.035  INFO 1 --- [           main] s.b.c.e.t.TomcatEmbeddedServletContainer : Tomcat started on port(s): 8080 (http)
-2015-03-31 13:25:48.037  INFO 1 --- [           main] hello.Application
-----
-====
-
-You can see it start up as normal. You might also notice that the JVM memory requirements were computed and set as command line options inside the container. This is the same memory calculation that has been in use in Cloud Foundry build packs for many years. It represents significant research into the best choices for a range of JVM applications, including but not limited to Spring Boot applications, and the results are usually much better than the default setting from the JVM. You can customize the command line options and override the memory calculator by setting environment variables.
 
 === Jib Maven and Gradle Plugins
 
@@ -887,57 +871,175 @@ For a (realistic) docker repository that needs authentication in the build serve
 
 == Buildpacks
 
-NOTE: The Spring Boot Maven and Gradle plugins use buildpacks in exactly the same way that the `pack` CLI does in the following examples. The main difference is that the plugins use `docker` to run the builds, whereas `pack` does not need to. The resulting images are identical, given the same inputs.
+NOTE: The Spring Boot Maven and Gradle plugins use buildpacks in exactly the same way that the `pack` CLI does in the following examples.
+The resulting images are identical, given the same inputs.
 
 https://www.cloudfoundry.org/[Cloud Foundry] has used containers internally for many years now, and part of the technology used to transform user code into containers is Build Packs, an idea originally borrowed from https://www.heroku.com/[Heroku]. The current generation of buildpacks (v2) generates generic binary output that is assembled into a container by the platform. The https://buildpacks.io/[new generation of buildpacks] (v3) is a collaboration between Heroku and other companies (including VMware), and it builds container images directly and explicitly. This is interesting for developers and operators. Developers do not need to care much about the details of how to build a container, but they can easily create one if they need to. Buildpacks also have lots of features for caching build results and dependencies. Often, a buildpack runs much more quickly than a native Docker build. Operators can scan the containers to audit their contents and transform them to patch them for security updates. Also, you can run the buildpacks locally (for example, on a developer machine or in a CI service) or in a platform like Cloud Foundry.
 
-The output from a buildpack lifecycle is a container image, but you do not need Docker or a `Dockerfile`, so it is CI and automation friendly. The filesystem layers in the output image are controlled by the buildpack. Typically, many optimizations are made without the developer having to know or care about them. There is also an https://en.wikipedia.org/wiki/Application_binary_interface[Application Binary Interface] between the lower level layers (such as the base image containing the operating system) and the upper layers (containing middleware and language specific dependencies). This makes it possible for a platform, such as Cloud Foundry, to patch lower layers if there are security updates without affecting the integrity and functionality of the application.
+The output from a buildpack lifecycle is a container image, but you do not need a `Dockerfile`. The filesystem layers in the output image are controlled by the buildpack. Typically, many optimizations are made without the developer having to know or care about them. There is also an https://en.wikipedia.org/wiki/Application_binary_interface[Application Binary Interface] between the lower level layers (such as the base image containing the operating system) and the upper layers (containing middleware and language specific dependencies). This makes it possible for a platform, such as Cloud Foundry, to patch lower layers if there are security updates without affecting the integrity and functionality of the application.
 
-To give you an idea of the features of a buildpack, the following example (shown with its output) uses the https://github.com/buildpack/pack[Pack CLI] from the command line (it would work with the sample application we have been using in this guide -- no need for a `Dockerfile` or any special build configuration):
+To give you an idea of the features of a buildpack, the following example (shown with its output) uses the https://buildpacks.io/docs/tools/pack/[Pack CLI] from the command line (it would work with the sample application we have been using in this guide -- no need for a `Dockerfile` or any special build configuration):
 
 ====
 [source,bash]
 ----
-pack build myorg/myapp --builder=cloudfoundry/cnb:bionic --path=.
-2018/11/07 09:54:48 Pulling builder image 'cloudfoundry/cnb:bionic' (use --no-pull flag to skip this step)
-2018/11/07 09:54:49 Selected run image 'packs/run' from stack 'io.buildpacks.stacks.bionic'
-2018/11/07 09:54:49 Pulling run image 'packs/run' (use --no-pull flag to skip this step)
-*** DETECTING:
-2018/11/07 09:54:52 Group: Cloud Foundry OpenJDK Buildpack: pass | Cloud Foundry Build System Buildpack: pass | Cloud Foundry JVM Application Buildpack: pass
-*** ANALYZING: Reading information from previous image for possible re-use
-*** BUILDING:
------> Cloud Foundry OpenJDK Buildpack 1.0.0-BUILD-SNAPSHOT
------> OpenJDK JDK 1.8.192: Reusing cached dependency
------> OpenJDK JRE 1.8.192: Reusing cached launch layer
+pack build myorg/myapp --builder=paketobuildpacks/builder:base --path=.
+base: Pulling from paketobuildpacks/builder
+Digest: sha256:4fae5e2abab118ca9a37bf94ab42aa17fef7c306296b0364f5a0e176702ab5cb
+Status: Image is up to date for paketobuildpacks/builder:base
+base-cnb: Pulling from paketobuildpacks/run
+Digest: sha256:a285e73bc3697bc58c228b22938bc81e9b11700e087fd9d44da5f42f14861812
+Status: Image is up to date for paketobuildpacks/run:base-cnb
+===> DETECTING
+7 of 18 buildpacks participating
+paketo-buildpacks/ca-certificates   2.3.2
+paketo-buildpacks/bellsoft-liberica 8.2.0
+paketo-buildpacks/maven             5.3.2
+paketo-buildpacks/executable-jar    5.1.2
+paketo-buildpacks/apache-tomcat     5.6.1
+paketo-buildpacks/dist-zip          4.1.2
+paketo-buildpacks/spring-boot       4.4.2
+===> ANALYZING
+Previous image with name "myorg/myapp" not found
+===> RESTORING
+===> BUILDING
 
------> Cloud Foundry Build System Buildpack 1.0.0-BUILD-SNAPSHOT
------> Using Maven wrapper
-       Linking Maven Cache to /home/pack/.m2
------> Building application
-       Running /workspace/app/mvnw -Dmaven.test.skip=true package
-...
----> Running in e6c4a94240c2
----> 4f3a96a4f38c
----> 4f3a96a4f38c
-Successfully built 4f3a96a4f38c
-Successfully tagged myorg/myapp:latest
-docker run -p 8080:8080 myorg/myapp
-.   ____          _            __ _ _
-/\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
-( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
-\\/  ___)| |_)| | | | | || (_| |  ) ) ) )
-'  |____| .__|_| |_|_| |_\__, | / / / /
-=========|_|==============|___/=/_/_/_/
- :: Spring Boot ::        (v2.3.0.RELEASE)
+Paketo CA Certificates Buildpack 2.3.2
+  https://github.com/paketo-buildpacks/ca-certificates
+  Launch Helper: Contributing to layer
+    Creating /layers/paketo-buildpacks_ca-certificates/helper/exec.d/ca-certificates-helper
 
-2018-11-07 09:41:06.390  INFO 1 --- [main] hello.Application: Starting Application on 1989fb9a00a4 with PID 1 (/workspace/app/BOOT-INF/classes started by pack in /workspace/app)
-...
+Paketo BellSoft Liberica Buildpack 8.2.0
+  https://github.com/paketo-buildpacks/bellsoft-liberica
+  Build Configuration:
+    $BP_JVM_VERSION              11              the Java version
+  Launch Configuration:
+    $BPL_JVM_HEAD_ROOM           0               the headroom in memory calculation
+    $BPL_JVM_LOADED_CLASS_COUNT  35% of classes  the number of loaded classes in memory calculation
+    $BPL_JVM_THREAD_COUNT        250             the number of threads in memory calculation
+    $JAVA_TOOL_OPTIONS                           the JVM launch flags
+  BellSoft Liberica JDK 11.0.12: Contributing to layer
+    Downloading from https://github.com/bell-sw/Liberica/releases/download/11.0.12+7/bellsoft-jdk11.0.12+7-linux-amd64.tar.gz
+    Verifying checksum
+    Expanding to /layers/paketo-buildpacks_bellsoft-liberica/jdk
+    Adding 129 container CA certificates to JVM truststore
+    Writing env.build/JAVA_HOME.override
+    Writing env.build/JDK_HOME.override
+  BellSoft Liberica JRE 11.0.12: Contributing to layer
+    Downloading from https://github.com/bell-sw/Liberica/releases/download/11.0.12+7/bellsoft-jre11.0.12+7-linux-amd64.tar.gz
+    Verifying checksum
+    Expanding to /layers/paketo-buildpacks_bellsoft-liberica/jre
+    Adding 129 container CA certificates to JVM truststore
+    Writing env.launch/BPI_APPLICATION_PATH.default
+    Writing env.launch/BPI_JVM_CACERTS.default
+    Writing env.launch/BPI_JVM_CLASS_COUNT.default
+    Writing env.launch/BPI_JVM_SECURITY_PROVIDERS.default
+    Writing env.launch/JAVA_HOME.default
+    Writing env.launch/MALLOC_ARENA_MAX.default
+  Launch Helper: Contributing to layer
+    Creating /layers/paketo-buildpacks_bellsoft-liberica/helper/exec.d/active-processor-count
+    Creating /layers/paketo-buildpacks_bellsoft-liberica/helper/exec.d/java-opts
+    Creating /layers/paketo-buildpacks_bellsoft-liberica/helper/exec.d/link-local-dns
+    Creating /layers/paketo-buildpacks_bellsoft-liberica/helper/exec.d/memory-calculator
+    Creating /layers/paketo-buildpacks_bellsoft-liberica/helper/exec.d/openssl-certificate-loader
+    Creating /layers/paketo-buildpacks_bellsoft-liberica/helper/exec.d/security-providers-configurer
+    Creating /layers/paketo-buildpacks_bellsoft-liberica/helper/exec.d/security-providers-classpath-9
+  JVMKill Agent 1.16.0: Contributing to layer
+    Downloading from https://github.com/cloudfoundry/jvmkill/releases/download/v1.16.0.RELEASE/jvmkill-1.16.0-RELEASE.so
+    Verifying checksum
+    Copying to /layers/paketo-buildpacks_bellsoft-liberica/jvmkill
+    Writing env.launch/JAVA_TOOL_OPTIONS.append
+    Writing env.launch/JAVA_TOOL_OPTIONS.delim
+  Java Security Properties: Contributing to layer
+    Writing env.launch/JAVA_SECURITY_PROPERTIES.default
+    Writing env.launch/JAVA_TOOL_OPTIONS.append
+    Writing env.launch/JAVA_TOOL_OPTIONS.delim
+
+Paketo Maven Buildpack 5.3.2
+  https://github.com/paketo-buildpacks/maven
+  Build Configuration:
+    $BP_MAVEN_BUILD_ARGUMENTS  -Dmaven.test.skip=true package  the arguments to pass to Maven
+    $BP_MAVEN_BUILT_ARTIFACT   target/*.[jw]ar                 the built application artifact explicitly.  Supersedes $BP_MAVEN_BUILT_MODULE
+    $BP_MAVEN_BUILT_MODULE                                     the module to find application artifact in
+    Creating cache directory /home/cnb/.m2
+  Compiled Application: Contributing to layer
+    Executing mvnw --batch-mode -Dmaven.test.skip=true package
+
+[ ... Maven build output ... ]
+
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  53.474 s
+[INFO] Finished at: 2021-07-23T20:10:28Z
+[INFO] ------------------------------------------------------------------------
+  Removing source code
+
+Paketo Executable JAR Buildpack 5.1.2
+  https://github.com/paketo-buildpacks/executable-jar
+  Class Path: Contributing to layer
+    Writing env/CLASSPATH.delim
+    Writing env/CLASSPATH.prepend
+  Process types:
+    executable-jar: java org.springframework.boot.loader.JarLauncher (direct)
+    task:           java org.springframework.boot.loader.JarLauncher (direct)
+    web:            java org.springframework.boot.loader.JarLauncher (direct)
+
+Paketo Spring Boot Buildpack 4.4.2
+  https://github.com/paketo-buildpacks/spring-boot
+  Creating slices from layers index
+    dependencies
+    spring-boot-loader
+    snapshot-dependencies
+    application
+  Launch Helper: Contributing to layer
+    Creating /layers/paketo-buildpacks_spring-boot/helper/exec.d/spring-cloud-bindings
+  Spring Cloud Bindings 1.7.1: Contributing to layer
+    Downloading from https://repo.spring.io/release/org/springframework/cloud/spring-cloud-bindings/1.7.1/spring-cloud-bindings-1.7.1.jar
+    Verifying checksum
+    Copying to /layers/paketo-buildpacks_spring-boot/spring-cloud-bindings
+  Web Application Type: Contributing to layer
+    Reactive web application detected
+    Writing env.launch/BPL_JVM_THREAD_COUNT.default
+  4 application slices
+  Image labels:
+    org.opencontainers.image.title
+    org.opencontainers.image.version
+    org.springframework.boot.version
+===> EXPORTING
+Adding layer 'paketo-buildpacks/ca-certificates:helper'
+Adding layer 'paketo-buildpacks/bellsoft-liberica:helper'
+Adding layer 'paketo-buildpacks/bellsoft-liberica:java-security-properties'
+Adding layer 'paketo-buildpacks/bellsoft-liberica:jre'
+Adding layer 'paketo-buildpacks/bellsoft-liberica:jvmkill'
+Adding layer 'paketo-buildpacks/executable-jar:classpath'
+Adding layer 'paketo-buildpacks/spring-boot:helper'
+Adding layer 'paketo-buildpacks/spring-boot:spring-cloud-bindings'
+Adding layer 'paketo-buildpacks/spring-boot:web-application-type'
+Adding 5/5 app layer(s)
+Adding layer 'launcher'
+Adding layer 'config'
+Adding layer 'process-types'
+Adding label 'io.buildpacks.lifecycle.metadata'
+Adding label 'io.buildpacks.build.metadata'
+Adding label 'io.buildpacks.project.metadata'
+Adding label 'org.opencontainers.image.title'
+Adding label 'org.opencontainers.image.version'
+Adding label 'org.springframework.boot.version'
+Setting default process type 'web'
+Saving myorg/myapp...
+*** Images (ed1f92885df0):
+      myorg/myapp
+Adding cache layer 'paketo-buildpacks/bellsoft-liberica:jdk'
+Adding cache layer 'paketo-buildpacks/maven:application'
+Adding cache layer 'paketo-buildpacks/maven:cache'
+Successfully built image 'myorg/myapp'
 ----
 ====
 
-The `--builder` is a docker image that runs the buildpack lifecycle. Typically, it would be a shared resource for all developers or all developers on a single platform. You can set the default builder on the command line (creates a file in `~/.pack`) and then omit that flag from subsequent builds.
+The `--builder` is a Docker image that runs the buildpack lifecycle. Typically, it would be a shared resource for all developers or all developers on a single platform. You can set the default builder on the command line (creates a file in `~/.pack`) and then omit that flag from subsequent builds.
 
-NOTE: The `cloudfoundry/cnb:bionic` builder also knows how to build an image from an executable JAR file, so you can build using `mvnw` first and then point the `--path` to the JAR file for the same result.
+NOTE: The `paketobuildpacks/builder:base` builder also knows how to build an image from an executable JAR file, so you can build using Maven first and then point the `--path` to the JAR file for the same result.
 
 == Knative
 

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -6,17 +6,20 @@ COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml .
 COPY src src
-
 RUN --mount=type=cache,target=/root/.m2 ./mvnw install -DskipTests
-WORKDIR /workspace/app/target/dependency
-RUN jar -xf ../*.jar
+
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} target/application.jar
+RUN java -Djarmode=layertools -jar target/application.jar extract --destination target/extracted
 
 FROM openjdk:8-jdk-alpine
 RUN addgroup -S demo && adduser -S demo -G demo
 VOLUME /tmp
 USER demo
-ARG DEPENDENCY=/workspace/app/target/dependency
-COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
-COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
-COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
-ENTRYPOINT ["java","-noverify","-XX:TieredStopAtLevel=1","-cp","app:app/lib/*","-Dspring.main.lazy-initialization=true","com.example.demo.DemoApplication"]
+ARG EXTRACTED=/workspace/app/target/extracted
+WORKDIR application
+COPY --from=build ${EXTRACTED}/dependencies/ ./
+COPY --from=build ${EXTRACTED}/spring-boot-loader/ ./
+COPY --from=build ${EXTRACTED}/snapshot-dependencies/ ./
+COPY --from=build ${EXTRACTED}/application/ ./
+ENTRYPOINT ["java","-noverify","-XX:TieredStopAtLevel=1","-Dspring.main.lazy-initialization=true","org.springframework.boot.loader.JarLauncher"]

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.0.RELEASE</version>
+		<version>2.5.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -48,42 +48,5 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<repositories>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
 
 </project>

--- a/demo/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/demo/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -1,11 +1,9 @@
 package com.example.demo;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.Test;
 
-@RunWith(SpringRunner.class)
+import org.springframework.boot.test.context.SpringBootTest;
+
 @SpringBootTest
 public class DemoApplicationTests {
 


### PR DESCRIPTION
This PR updates the content of this guide with the following changes: 

* Merges duplicate `Spring Boot Plugins` and `Spring Boot Maven and Gradle Plugin` sections
* Updates sample output from Spring Boot plugins to match current actual output
* Adds a section on Spring Boot layer tools as an alternative to manually unzipping jar contents into layers
* Updates `Buildpacks` section to reflect Paketo builder and buildpacks as the current CNB implementation

The `demo` application has also been updated to use the Spring Boot layertools technique for layering.