### PR TITLE
fix not working unpack command to gradle example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -514,7 +514,7 @@ WORKDIR /workspace/app
 
 COPY . /workspace/app
 RUN --mount=type=cache,target=/root/.gradle ./gradlew clean build
-RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*.jar)
+RUN mkdir -p build/dependency && (cd build/dependency; find ../libs -name "*.jar" -exec jar -xf {} \;)
 
 FROM eclipse-temurin:17-jdk-alpine
 VOLUME /tmp

--- a/README.adoc
+++ b/README.adoc
@@ -514,7 +514,7 @@ WORKDIR /workspace/app
 
 COPY . /workspace/app
 RUN --mount=type=cache,target=/root/.gradle ./gradlew clean build
-RUN mkdir -p build/dependency && (cd build/dependency; find ../libs -name "*.jar" -exec jar -xf {} \;)
+RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*-SNAPSHOT.jar)
 
 FROM eclipse-temurin:17-jdk-alpine
 VOLUME /tmp


### PR DESCRIPTION
## Problem

While following the guide, I found that the gradle Dockerfile example of [Multi-Stage Build](https://github.com/spring-guides/top-spring-boot-docker#multi-stage-build) did not working.

```
# syntax=docker/dockerfile:experimental
FROM eclipse-temurin:17-jdk-alpine AS build
WORKDIR /workspace/app

COPY . /workspace/app
RUN --mount=type=cache,target=/root/.gradle ./gradlew clean build
RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*.jar)

FROM eclipse-temurin:17-jdk-alpine
VOLUME /tmp
ARG DEPENDENCY=/workspace/app/build/dependency
COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
ENTRYPOINT ["java","-cp","app:app/lib/*","hello.Application"]
```

The unpack command(`jar -xf ../libs/*.jar`) in the example above doens't work.

The other examples worked fine, so I looked for differences.
### work
```
jar -xf ../*.jar
```

### not work
```
jar -xf ../libs/*.jar
```

For some reason, the `*` pattern doesn't seem to work when the path contains directories.  
(It was the same on macOS terminal.)

## Solve
```
find ../libs -name "*.jar" -exec jar -xf {} \;
```
reference: https://stackoverflow.com/questions/45975019/extract-several-of-jar-in-one-command


Because it is a translator, sentences can be awkward.
Thanks for reading 😄