### PR TITLE
Fix errors found while following along

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -266,7 +266,7 @@ FROM eclipse-temurin:17-jdk-alpine
 VOLUME /tmp
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar /app.jar ${0} ${@}"]
+ENTRYPOINT ["sh", "-c", "java -jar /app.jar ${0} ${@}"]
 ----
 ====
 

--- a/README.adoc
+++ b/README.adoc
@@ -146,7 +146,7 @@ FROM eclipse-temurin:17-jdk-alpine
 VOLUME /tmp
 COPY run.sh .
 COPY target/*.jar app.jar
-ENTRYPOINT ["run.sh"]
+ENTRYPOINT ["./run.sh"]
 ----
 ====
 

--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,7 @@ You could pass in the `JAR_FILE` as part of the `docker` command (it differs for
 ====
 [source,bash]
 ----
-docker build --build-arg JAR_FILE=target/*.jar -t myorg/myapp .
+docker build --build-arg JAR_FILE=target/\*.jar -t myorg/myapp .
 ----
 ====
 
@@ -44,7 +44,7 @@ For Gradle, the following command works:
 ====
 [source,bash]
 ----
-docker build --build-arg JAR_FILE=build/libs/*.jar -t myorg/myapp .
+docker build --build-arg JAR_FILE=build/libs/\*.jar -t myorg/myapp .
 ----
 ====
 


### PR DESCRIPTION
- escape * character when docker build
- Fix Dockerfile script that uses run.sh
- ${JAVA_OPTS} is unnecessary part