### PR TITLE
fix reference to JarLauncher class

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -381,7 +381,7 @@ COPY ${EXTRACTED}/dependencies/ ./
 COPY ${EXTRACTED}/spring-boot-loader/ ./
 COPY ${EXTRACTED}/snapshot-dependencies/ ./
 COPY ${EXTRACTED}/application/ ./
-ENTRYPOINT ["java","org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java","org.springframework.boot.loader.launch.JarLauncher"]
 ----
 ====
 


### PR DESCRIPTION
The [Spring Boot Docker Getting Started Guide](https://spring.io/guides/topicals/spring-boot-docker/) still references the old `org.springframework.boot.loader.JarLauncher` class.  It should reference the relocated `org.springframework.boot.loader.launch.JarLauncher`.

Classes were relocated in https://github.com/spring-projects/spring-boot/issues/37667

This is being [called out in the upgrade notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.2-Release-Notes#nested-jar-support).

fixes: https://github.com/spring-guides/top-spring-boot-docker/issues/32