### PR TITLE
Fixing incorrect docker command

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -9,7 +9,7 @@ COPY src src
 RUN --mount=type=cache,target=/root/.m2 ./mvnw install -DskipTests
 
 ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} target/application.jar
+RUN mv ${JAR_FILE} target/application.jar
 RUN java -Djarmode=layertools -jar target/application.jar extract --destination target/extracted
 
 FROM eclipse-temurin:17-jdk-alpine


### PR DESCRIPTION
The first stage of this Dockerfile runs COPY from the host machine into the container.

The intent is to rename the jar already built *in* the container for use in the second stage, hence RUN mv.